### PR TITLE
Add an ignore tag "-" like encoding/json

### DIFF
--- a/asn1_test.go
+++ b/asn1_test.go
@@ -430,6 +430,38 @@ func TestDerSet(t *testing.T) {
 	}
 }
 
+func TestIgnore(t *testing.T) {
+	type Type struct {
+		B string
+		C bool `asn1:"-"`
+	}
+	encodeTest := testCase{
+		Type{"abc", true},
+		[]byte{
+			// SEQ LEN=8
+			0x30, 0x05,
+			// OCTETSTRING LEN=3
+			0x04, 0x03,
+			// "abc"
+			0x61, 0x62, 0x63,
+		},
+	}
+	decodeTest := testCase{
+		Type{"abc", false},
+		[]byte{
+			// SEQ LEN=8
+			0x30, 0x05,
+			// OCTETSTRING LEN=3
+			0x04, 0x03,
+			// "abc"
+			0x61, 0x62, 0x63,
+		},
+	}
+	ctx := NewContext()
+	testEncode(t, ctx, "", encodeTest)
+	testDecode(t, ctx, "", decodeTest)
+}
+
 func TestOptional(t *testing.T) {
 	type Type struct {
 		A int `asn1:"optional"`

--- a/context.go
+++ b/context.go
@@ -169,6 +169,10 @@ func (ctx *Context) AddChoice(choice string, entries []Choice) error {
 		if err != nil {
 			return err
 		}
+		// Skip if the ignore tag is given
+		if opts == nil {
+			continue
+		}
 		if opts.choice != nil {
 			// TODO Add support for nested choices.
 			return syntaxError(

--- a/decode.go
+++ b/decode.go
@@ -138,6 +138,10 @@ func (ctx *Context) DecodeWithOptions(data []byte, obj interface{}, options stri
 	if err != nil {
 		return nil, err
 	}
+	// Return nil if the ignore tag is given
+	if opts == nil {
+		return
+	}
 
 	value := reflect.ValueOf(obj)
 	switch value.Kind() {
@@ -340,6 +344,10 @@ func (ctx *Context) getExpectedFieldElements(value reflect.Value) ([]expectedFie
 			opts, err := parseOptions(value.Type().Field(i).Tag.Get(tagKey))
 			if err != nil {
 				return nil, err
+			}
+			// Skip if the ignore tag is given
+			if opts == nil {
+				continue
 			}
 			// Expand choices
 			raw := &rawValue{}

--- a/encode.go
+++ b/encode.go
@@ -23,6 +23,10 @@ func (ctx *Context) EncodeWithOptions(obj interface{}, options string) (data []b
 	if err != nil {
 		return nil, err
 	}
+	// Return nil if the ignore tag is given
+	if opts == nil {
+		return
+	}
 
 	value := reflect.ValueOf(obj)
 	raw, err := ctx.encode(value, opts)
@@ -229,6 +233,10 @@ func (ctx *Context) getRawValuesFromFields(value reflect.Value) ([]*rawValue, er
 			opts, err := parseOptions(tag)
 			if err != nil {
 				return nil, err
+			}
+			// Skip if the ignore tag is given
+			if opts == nil {
+				continue
 			}
 			raw, err := ctx.encode(fieldValue, opts)
 			if err != nil {

--- a/options.go
+++ b/options.go
@@ -38,8 +38,11 @@ func (opts *fieldOptions) validate() error {
 	return nil
 }
 
-// parseOption returns a parsed fieldOptions or an error.
+// parseOption returns a parsed fieldOptions or an error. Returns nil for the ignore tag "-".
 func parseOptions(s string) (*fieldOptions, error) {
+	if s == "-" {
+		return nil, nil
+	}
 	var opts fieldOptions
 	for _, token := range strings.Split(s, ",") {
 		args := strings.Split(strings.TrimSpace(token), ":")


### PR DESCRIPTION
In the json package a tag `json:"-"` indicates that the field should be ignored during encoding or decoding. This PR adds a similar tag to asn1: `asn1:"-"`.